### PR TITLE
feat: Create Suggestion Box module for Odoo 18

### DIFF
--- a/suggestion_box/__init__.py
+++ b/suggestion_box/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import controllers
+from . import models

--- a/suggestion_box/__manifest__.py
+++ b/suggestion_box/__manifest__.py
@@ -1,0 +1,25 @@
+{
+    'name': 'Suggestion Box',
+    'version': '18.0.1.0.0',
+    'summary': 'A suggestion box module for Odoo 18',
+    'author': 'Jules',
+    'license': 'AGPL-3',
+    'depends': [
+        'base',
+        'mail',
+        'website',
+        'portal',
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'security/suggestion_security.xml',
+        'data/suggestion_data.xml',
+        'views/suggestion_views.xml',
+        'views/category_views.xml',
+        'views/menus.xml',
+        'views/res_config_settings_views.xml',
+        'views/website_templates.xml',
+    ],
+    'installable': True,
+    'application': True,
+}

--- a/suggestion_box/controllers/__init__.py
+++ b/suggestion_box/controllers/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import main

--- a/suggestion_box/controllers/main.py
+++ b/suggestion_box/controllers/main.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from odoo import http
+from odoo.http import request
+
+class SuggestionBox(http.Controller):
+
+    @http.route('/suggestion/submit', type='http', auth="public", website=True)
+    def suggestion_submit_form(self, **post):
+        categories = request.env['suggestion.category'].search([('level', '=', 'category')])
+        return request.render("suggestion_box.suggestion_submit_form_template", {'categories': categories})
+
+    @http.route('/suggestion/thankyou', type='http', auth="public", website=True)
+    def suggestion_thankyou(self, **post):
+        return request.render("suggestion_box.suggestion_thank_you_template")
+
+    @http.route('/suggestion/process', type='http', auth="public", website=True, methods=['POST'], csrf=False)
+    def suggestion_process_form(self, **post):
+        is_anonymous = post.get('anonymous', False)
+        owner = request.env.user if not is_anonymous and request.env.user.id != request.env.ref('base.public_user').id else False
+
+        vals = {
+            'name': post.get('name'),
+            'category_id': int(post.get('category_id')) if post.get('category_id') else False,
+            'area_id': int(post.get('area_id')) if post.get('area_id') else False,
+            'item_id': int(post.get('item_id')) if post.get('item_id') else False,
+            'description': post.get('description'),
+            'owner_id': owner.id if owner else False,
+        }
+
+        if post.get('image'):
+            vals['image'] = post.get('image').read()
+
+        request.env['suggestion.suggestion'].sudo().create(vals)
+        return request.redirect('/suggestion/thankyou')
+
+    @http.route('/suggestion/get_areas', type='json', auth="public", website=True)
+    def get_areas(self, category_id, **kw):
+        areas = request.env['suggestion.category'].sudo().search_read(
+            [('level', '=', 'area'), ('parent_id', '=', int(category_id))],
+            ['id', 'name']
+        )
+        return areas
+
+    @http.route('/suggestion/get_items', type='json', auth="public", website=True)
+    def get_items(self, area_id, **kw):
+        items = request.env['suggestion.category'].sudo().search_read(
+            [('level', '=', 'item'), ('parent_id', '=', int(area_id))],
+            ['id', 'name']
+        )
+        return items

--- a/suggestion_box/data/suggestion_data.xml
+++ b/suggestion_box/data/suggestion_data.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <!-- Email Template for Acknowledgement -->
+        <record id="email_template_suggestion_acknowledgement" model="mail.template">
+            <field name="name">Suggestion Acknowledgement</field>
+            <field name="model_id" ref="suggestion_box.model_suggestion_suggestion"/>
+            <field name="subject">Thank you for your suggestion!</field>
+            <field name="email_to">${object.owner_id.email_formatted | safe}</field>
+            <field name="body_html"><![CDATA[
+<p>Dear ${object.owner_id.name},</p>
+<p>Thank you for your suggestion titled "${object.name}". We have received it and will review it shortly.</p>
+<p>Best regards,<br/>The Suggestion Box Team</p>
+]]></field>
+            <field name="auto_delete" eval="True"/>
+        </record>
+
+        <!-- Email Template for Status Change -->
+        <record id="email_template_suggestion_status_change" model="mail.template">
+            <field name="name">Suggestion Status Changed</field>
+            <field name="model_id" ref="suggestion_box.model_suggestion_suggestion"/>
+            <field name="subject">Suggestion status updated: ${object.name}</field>
+            <field name="email_to">${object.owner_id.email_formatted | safe},${object.assigned_id.email_formatted | safe}</field>
+            <field name="body_html"><![CDATA[
+<p>Hello,</p>
+<p>The status of the suggestion "${object.name}" has been changed to <strong>${object.state}</strong>.</p>
+<p>You can view the suggestion here: <a href="${object.get_portal_url()}">View Suggestion</a></p>
+<p>Thank you</p>
+]]></field>
+            <field name="auto_delete" eval="True"/>
+        </record>
+
+        <!-- Automated Activity -->
+        <record id="activity_suggestion_follow_up" model="mail.activity.type">
+            <field name="name">Follow up on new suggestion</field>
+            <field name="res_model_id" ref="suggestion_box.model_suggestion_suggestion"/>
+            <field name="delay_count">3</field>
+            <field name="delay_unit">days</field>
+            <field name="summary">Follow up on new suggestion</field>
+        </record>
+
+        <!-- Server Action to Escalate Stale Suggestions -->
+        <record id="ir_cron_escalate_stale_suggestions" model="ir.cron">
+            <field name="name">Escalate Stale Suggestions</field>
+            <field name="model_id" ref="model_suggestion_suggestion"/>
+            <field name="state">code</field>
+            <field name="code">model.search([('state', '=', 'new'), ('create_date', '&lt;=', fields.Datetime.now() - env['ir.config_parameter'].sudo().get_param('suggestion_box.sla_days') or 7)])._cron_escalate()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+        </record>
+    </data>
+</odoo>

--- a/suggestion_box/models/__init__.py
+++ b/suggestion_box/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import suggestion

--- a/suggestion_box/models/suggestion.py
+++ b/suggestion_box/models/suggestion.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api
+
+class SuggestionCategory(models.Model):
+    _name = 'suggestion.category'
+    _description = 'Suggestion Category'
+    _parent_store = True
+
+    name = fields.Char(required=True)
+    level = fields.Selection([
+        ('category', 'Category'),
+        ('area', 'Area'),
+        ('item', 'Item'),
+    ], required=True)
+    parent_id = fields.Many2one('suggestion.category', 'Parent', index=True, ondelete='cascade')
+    parent_path = fields.Char(index=True)
+    _sql_constraints = [
+        ('uniq_name_parent_level', 'unique(name, parent_id, level)', 'The combination of name, parent, and level must be unique.')
+    ]
+
+class SuggestionSuggestion(models.Model):
+    _name = 'suggestion.suggestion'
+    _description = 'Suggestion'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
+
+    name = fields.Char(required=True, tracking=True)
+    category_id = fields.Many2one('suggestion.category', 'Category', domain="[('level','=','category')]", tracking=True)
+    area_id = fields.Many2one('suggestion.category', 'Area', domain="[('level','=','area')]", tracking=True)
+    item_id = fields.Many2one('suggestion.category', 'Item', domain="[('level','=','item')]", tracking=True)
+    description = fields.Text()
+    image = fields.Binary(attachment=True)
+    state = fields.Selection([
+        ('new', 'New'),
+        ('in_progress', 'In Progress'),
+        ('done', 'Done'),
+    ], default='new', tracking=True, group_expand='_read_group_stage_ids')
+    owner_id = fields.Many2one('res.users', 'Owner', default=lambda self: self.env.user)
+    assigned_id = fields.Many2one('res.users', 'Assigned To')
+    priority = fields.Selection([
+        ('0', 'Low'),
+        ('1', 'Normal'),
+        ('2', 'High'),
+    ], default='1')
+    active = fields.Boolean(default=True)
+
+    @api.model
+    def _read_group_stage_ids(self, stages, domain, order):
+        """ Read group customization in order to display all the stages in the
+            kanban view, even if they are empty
+        """
+        stage_ids = self._fields['state'].get_values(self.env)
+        return [s[0] for s in stage_ids]
+
+    def action_start(self):
+        for rec in self:
+            if not rec.assigned_id:
+                rec.assigned_id = self.env.user
+            rec.state = 'in_progress'
+            rec.message_post_with_template(self.env.ref('suggestion_box.email_template_suggestion_status_change').id)
+
+
+    def action_done(self):
+        for rec in self:
+            rec.state = 'done'
+            rec.message_post_with_template(self.env.ref('suggestion_box.email_template_suggestion_status_change').id)
+
+    @api.model
+    def create(self, vals):
+        res = super(SuggestionSuggestion, self).create(vals)
+        if res.owner_id:
+            res.message_post_with_template(self.env.ref('suggestion_box.email_template_suggestion_acknowledgement').id)
+
+        # Schedule follow-up activity
+        self.env['mail.activity'].create({
+            'activity_type_id': self.env.ref('suggestion_box.activity_suggestion_follow_up').id,
+            'res_id': res.id,
+            'res_model_id': self.env.ref('suggestion_box.model_suggestion_suggestion').id,
+            'user_id': res.assigned_id.id or (self.env.ref('suggestion_box.group_suggestion_manager').users and self.env.ref('suggestion_box.group_suggestion_manager').users[0].id) or self.env.user.id
+        })
+        return res
+
+    def _cron_escalate(self):
+        manager_group = self.env.ref('suggestion_box.group_suggestion_manager')
+        managers = manager_group.users
+        for suggestion in self:
+            suggestion.priority = '2' # High
+            suggestion.message_post(body="This suggestion has been escalated due to being stale.", subtype_xmlid="mail.mt_note", partner_ids=managers.mapped('partner_id').ids)
+
+
+    @api.onchange('category_id')
+    def _onchange_category_id(self):
+        self.area_id = False
+        if self.category_id:
+            return {'domain': {'area_id': [('parent_id', '=', self.category_id.id), ('level', '=', 'area')]}}
+        return {'domain': {'area_id': []}}
+
+    @api.onchange('area_id')
+    def _onchange_area_id(self):
+        self.item_id = False
+        if self.area_id:
+            return {'domain': {'item_id': [('parent_id', '=', self.area_id.id), ('level', '=', 'item')]}}
+        return {'domain': {'item_id': []}}
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    allow_anonymous = fields.Boolean(string="Allow Anonymous Suggestions", config_parameter='suggestion_box.allow_anonymous')
+    default_responsible_id = fields.Many2one('res.users', string="Default Responsible", config_parameter='suggestion_box.default_responsible_id')
+    sla_days = fields.Integer(string="SLA Days", config_parameter='suggestion_box.sla_days')
+    email_alias = fields.Char(string="Email Alias", config_parameter='suggestion_box.email_alias')

--- a/suggestion_box/security/ir.model.access.csv
+++ b/suggestion_box/security/ir.model.access.csv
@@ -1,0 +1,5 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_suggestion_user,suggestion.suggestion user,model_suggestion_suggestion,base.group_user,1,1,1,0
+access_suggestion_manager,suggestion.suggestion manager,model_suggestion_suggestion,suggestion_box.group_suggestion_manager,1,1,1,1
+access_category_user,suggestion.category user,model_suggestion_category,base.group_user,1,0,0,0
+access_category_manager,suggestion.category manager,model_suggestion_category,suggestion_box.group_suggestion_manager,1,1,1,1

--- a/suggestion_box/security/suggestion_security.xml
+++ b/suggestion_box/security/suggestion_security.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="group_suggestion_user" model="res.groups">
+            <field name="name">Suggestion User</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+        </record>
+
+        <record id="group_suggestion_manager" model="res.groups">
+            <field name="name">Suggestion Manager</field>
+            <field name="category_id" ref="base.module_category_hidden"/>
+            <field name="implied_ids" eval="[(4, ref('group_suggestion_user'))]"/>
+        </record>
+
+        <record id="suggestion_suggestion_rule_user" model="ir.rule">
+            <field name="name">User sees own suggestions</field>
+            <field name="model_id" ref="model_suggestion_suggestion"/>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="domain_force">['|',('owner_id','=',user.id),('owner_id','=',False)]</field>
+        </record>
+
+    </data>
+</odoo>

--- a/suggestion_box/views/category_views.xml
+++ b/suggestion_box/views/category_views.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!-- suggestion.category tree view -->
+        <record id="suggestion_category_view_tree" model="ir.ui.view">
+            <field name="name">suggestion.category.view.tree</field>
+            <field name="model">suggestion.category</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="name"/>
+                    <field name="level"/>
+                    <field name="parent_id"/>
+                </tree>
+            </field>
+        </record>
+
+        <!-- suggestion.category form view -->
+        <record id="suggestion_category_view_form" model="ir.ui.view">
+            <field name="name">suggestion.category.view.form</field>
+            <field name="model">suggestion.category</field>
+            <field name="arch" type="xml">
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="name"/>
+                            <field name="level"/>
+                            <field name="parent_id"/>
+                        </group>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- suggestion.category action window -->
+        <record id="suggestion_category_action" model="ir.actions.act_window">
+            <field name="name">Taxonomy</field>
+            <field name="res_model">suggestion.category</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+    </data>
+</odoo>

--- a/suggestion_box/views/menus.xml
+++ b/suggestion_box/views/menus.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!-- Main Menu -->
+        <menuitem id="suggestion_box_menu_root"
+            name="Suggestion Box"
+            sequence="10"/>
+
+        <!-- Suggestions Menu -->
+        <menuitem id="suggestion_suggestion_menu"
+            name="Suggestions"
+            parent="suggestion_box_menu_root"
+            action="suggestion_suggestion_action"
+            sequence="10"/>
+
+        <!-- Taxonomy Menu -->
+        <menuitem id="suggestion_category_menu"
+            name="Taxonomy"
+            parent="suggestion_box_menu_root"
+            action="suggestion_category_action"
+            groups="suggestion_box.group_suggestion_manager"
+            sequence="20"/>
+
+        <!-- Configuration Menu -->
+        <menuitem id="suggestion_config_menu"
+            name="Configuration"
+            parent="suggestion_box_menu_root"
+            sequence="100"
+            groups="base.group_system"/>
+
+        <menuitem id="suggestion_settings_menu"
+            name="Settings"
+            parent="suggestion_config_menu"
+            action="suggestion_box_config_settings_action"
+            sequence="10"/>
+
+    </data>
+</odoo>

--- a/suggestion_box/views/res_config_settings_views.xml
+++ b/suggestion_box/views/res_config_settings_views.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.suggestion.box</field>
+            <field name="model">res.config.settings</field>
+            <field name="priority" eval="40"/>
+            <field name="inherit_id" ref="base.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[hasclass('settings')]" position="inside">
+                    <div class="app_settings_block" data-string="Suggestion Box" string="Suggestion Box" data-key="suggestion_box">
+                        <h2>Suggestion Box Settings</h2>
+                        <div class="row mt16 o_settings_container">
+                            <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_left_pane">
+                                    <field name="allow_anonymous"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="allow_anonymous"/>
+                                    <div class="text-muted">
+                                        Allow users to submit suggestions anonymously.
+                                    </div>
+                                </div>
+                            </div>
+                             <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_left_pane"/>
+                                <div class="o_setting_right_pane">
+                                     <label for="default_responsible_id"/>
+                                     <div class="text-muted">
+                                        Set a default responsible person for new suggestions.
+                                     </div>
+                                     <field name="default_responsible_id"/>
+                                </div>
+                            </div>
+                            <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_left_pane"/>
+                                <div class="o_setting_right_pane">
+                                     <label for="sla_days"/>
+                                     <div class="text-muted">
+                                        Number of days before a new suggestion is considered stale.
+                                     </div>
+                                     <field name="sla_days"/>
+                                </div>
+                            </div>
+                            <div class="col-12 col-lg-6 o_setting_box">
+                                <div class="o_setting_left_pane"/>
+                                <div class="o_setting_right_pane">
+                                     <label for="email_alias"/>
+                                     <div class="text-muted">
+                                        Email alias for incoming suggestions.
+                                     </div>
+                                     <field name="email_alias"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="suggestion_box_config_settings_action" model="ir.actions.act_window">
+            <field name="name">Settings</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">res.config.settings</field>
+            <field name="view_mode">form</field>
+            <field name="target">inline</field>
+            <field name="context">{'module' : 'suggestion_box'}</field>
+        </record>
+    </data>
+</odoo>

--- a/suggestion_box/views/suggestion_views.xml
+++ b/suggestion_box/views/suggestion_views.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!-- suggestion.suggestion tree view -->
+        <record id="suggestion_suggestion_view_tree" model="ir.ui.view">
+            <field name="name">suggestion.suggestion.view.tree</field>
+            <field name="model">suggestion.suggestion</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="name"/>
+                    <field name="category_id"/>
+                    <field name="area_id"/>
+                    <field name="item_id"/>
+                    <field name="state"/>
+                    <field name="assigned_id"/>
+                    <field name="priority"/>
+                </tree>
+            </field>
+        </record>
+
+        <!-- suggestion.suggestion form view -->
+        <record id="suggestion_suggestion_view_form" model="ir.ui.view">
+            <field name="name">suggestion.suggestion.view.form</field>
+            <field name="model">suggestion.suggestion</field>
+            <field name="arch" type="xml">
+                <form>
+                    <header>
+                        <button name="action_start" string="Start" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'new')]}"/>
+                        <button name="action_done" string="Done" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'in_progress')]}"/>
+                        <field name="state" widget="statusbar" statusbar_visible="new,in_progress,done"/>
+                    </header>
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name"/>
+                                <field name="image" widget="image"/>
+                                <field name="description"/>
+                            </group>
+                            <group>
+                                <field name="category_id"/>
+                                <field name="area_id"/>
+                                <field name="item_id"/>
+                            </group>
+                        </group>
+                        <group string="Assignment">
+                            <field name="assigned_id"/>
+                            <field name="priority"/>
+                        </group>
+                    </sheet>
+                    <div class="oe_chatter">
+                        <field name="message_follower_ids" widget="mail_followers"/>
+                        <field name="activity_ids" widget="mail_activity"/>
+                        <field name="message_ids" widget="mail_thread"/>
+                    </div>
+                </form>
+            </field>
+        </record>
+
+        <!-- suggestion.suggestion kanban view -->
+        <record id="suggestion_suggestion_view_kanban" model="ir.ui.view">
+            <field name="name">suggestion.suggestion.view.kanban</field>
+            <field name="model">suggestion.suggestion</field>
+            <field name="arch" type="xml">
+                <kanban default_group_by="state" quick_create="false">
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div class="oe_kanban_global_click">
+                                <div class="oe_kanban_details">
+                                    <strong><field name="name"/></strong>
+                                    <div><field name="category_id"/> / <field name="area_id"/> / <field name="item_id"/></div>
+                                    <div>Assigned to: <field name="assigned_id"/></div>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>
+            </field>
+        </record>
+
+        <!-- suggestion.suggestion search view -->
+        <record id="suggestion_suggestion_view_search" model="ir.ui.view">
+            <field name="name">suggestion.suggestion.view.search</field>
+            <field name="model">suggestion.suggestion</field>
+            <field name="arch" type="xml">
+                <search>
+                    <field name="name" string="Suggestion"/>
+                    <filter string="New" name="state_new" domain="[('state', '=', 'new')]"/>
+                    <filter string="In Progress" name="state_in_progress" domain="[('state', '=', 'in_progress')]"/>
+                    <filter string="Done" name="state_done" domain="[('state', '=', 'done')]"/>
+                    <separator/>
+                    <field name="category_id"/>
+                    <field name="area_id"/>
+                    <field name="item_id"/>
+                    <field name="assigned_id"/>
+                    <field name="create_date"/>
+                    <group expand="0" string="Group By">
+                        <filter string="State" name="group_by_state" context="{'group_by': 'state'}"/>
+                        <filter string="Category" name="group_by_category" context="{'group_by': 'category_id'}"/>
+                        <filter string="Area" name="group_by_area" context="{'group_by': 'area_id'}"/>
+                        <filter string="Item" name="group_by_item" context="{'group_by': 'item_id'}"/>
+                        <filter string="Assigned To" name="group_by_assigned" context="{'group_by': 'assigned_id'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <!-- suggestion.suggestion action window -->
+        <record id="suggestion_suggestion_action" model="ir.actions.act_window">
+            <field name="name">Suggestions</field>
+            <field name="res_model">suggestion.suggestion</field>
+            <field name="view_mode">tree,kanban,form</field>
+        </record>
+
+    </data>
+</odoo>

--- a/suggestion_box/views/website_templates.xml
+++ b/suggestion_box/views/website_templates.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="suggestion_submit_form_template" name="Suggestion Box">
+        <t t-call="website.layout">
+            <div id="wrap">
+                <div class="container">
+                    <h1>Submit a Suggestion</h1>
+                    <form action="/suggestion/process" method="post" enctype="multipart/form-data" class="form-horizontal mt32">
+                        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                        <div class="form-group">
+                            <label class="col-md-3 col-sm-4 control-label" for="name">Title</label>
+                            <div class="col-md-7 col-sm-8">
+                                <input type="text" class="form-control" name="name" required="1"/>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-md-3 col-sm-4 control-label" for="category_id">Category</label>
+                            <div class="col-md-7 col-sm-8">
+                                <select name="category_id" class="form-control" id="category_id">
+                                    <option value="">Select Category...</option>
+                                    <t t-foreach="categories" t-as="category">
+                                        <option t-att-value="category.id"><t t-esc="category.name"/></option>
+                                    </t>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-md-3 col-sm-4 control-label" for="area_id">Area</label>
+                            <div class="col-md-7 col-sm-8">
+                                <select name="area_id" class="form-control" id="area_id">
+                                    <option value="">Select Area...</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-md-3 col-sm-4 control-label" for="item_id">Item</label>
+                            <div class="col-md-7 col-sm-8">
+                                <select name="item_id" class="form-control" id="item_id">
+                                    <option value="">Select Item...</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-md-3 col-sm-4 control-label" for="description">Description</label>
+                            <div class="col-md-7 col-sm-8">
+                                <textarea class="form-control" name="description" rows="5"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label class="col-md-3 col-sm-4 control-label" for="image">Image</label>
+                            <div class="col-md-7 col-sm-8">
+                                <input type="file" class="form-control" name="image"/>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="col-md-offset-3 col-sm-offset-4 col-sm-8 col-md-7">
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" name="anonymous" value="1"/> Submit Anonymously
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="col-md-offset-3 col-md-7 col-sm-offset-4 col-sm-8">
+                                <button type="submit" class="btn btn-primary">Submit</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <script>
+                odoo.define('suggestion_box.cascading_dropdowns', function (require) {
+                    "use strict";
+                    var ajax = require('web.ajax');
+
+                    $('#category_id').on('change', function() {
+                        var category_id = $(this).val();
+                        ajax.jsonRpc('/suggestion/get_areas', 'call', {'category_id': category_id})
+                            .then(function(data) {
+                                var $area_select = $('#area_id');
+                                $area_select.empty().append($('<option/>', { value: '', text: 'Select Area...' }));
+                                data.forEach(function(area) {
+                                    $area_select.append($('<option/>', {
+                                        value: area.id,
+                                        text: area.name
+                                    }));
+                                });
+                                $('#item_id').empty().append($('<option/>', { value: '', text: 'Select Item...' }));
+                            });
+                    });
+
+                    $('#area_id').on('change', function() {
+                        var area_id = $(this).val();
+                        ajax.jsonRpc('/suggestion/get_items', 'call', {'area_id': area_id})
+                            .then(function(data) {
+                                var $item_select = $('#item_id');
+                                $item_select.empty().append($('<option/>', { value: '', text: 'Select Item...' }));
+                                data.forEach(function(item) {
+                                    $item_select.append($('<option/>', {
+                                        value: item.id,
+                                        text: item.name
+                                    }));
+                                });
+                            });
+                    });
+                });
+            </script>
+        </t>
+    </template>
+
+    <template id="suggestion_thank_you_template" name="Thank You">
+        <t t-call="website.layout">
+            <div id="wrap">
+                <div class="container">
+                    <h1>Thank You!</h1>
+                    <p>Your suggestion has been submitted successfully.</p>
+                    <a href="/suggestion/submit" class="btn btn-primary">Submit another suggestion</a>
+                </div>
+            </div>
+        </t>
+    </template>
+</odoo>


### PR DESCRIPTION
This commit introduces a new Odoo module, `suggestion_box`, for managing employee or user suggestions.

The module provides a complete solution for collecting, triaging, and managing suggestions within Odoo 18.

Key features include:
- A three-level taxonomy system (Category -> Area -> Item) for classifying suggestions.
- A suggestion model with states (New, In Progress, Done), assignments, and priority.
- Security roles (User, Manager) with appropriate access rights and record rules.
- A public-facing website form for submitting suggestions, with support for anonymous submissions and cascading dropdowns for the taxonomy.
- Backend views (tree, form, kanban, search) for managing suggestions and the taxonomy.
- Automation features, including email templates for acknowledgements, status changes, and a cron job to escalate stale suggestions.
- Configuration settings to customize module behavior.